### PR TITLE
Update Sound Server Dependencies

### DIFF
--- a/ReefSoundServer/pom.xml
+++ b/ReefSoundServer/pom.xml
@@ -27,11 +27,6 @@
             <version>9.1.3.v20140225</version>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.jetty.aggregate</groupId>
-            <artifactId>jetty-all-server</artifactId>
-            <version>7.0.2.RC0</version>
-        </dependency>
-        <dependency>
             <groupId>org.java-websocket</groupId>
             <artifactId>Java-WebSocket</artifactId>
             <version>1.3.0</version>


### PR DESCRIPTION
Update ReefSoundServer dependencies due to a security flaws from CVE.

Temporary until base is aggregated to a newer version.